### PR TITLE
Enable standard flow on all RH SSO clients

### DIFF
--- a/roles/tssc-platform/configuration/crw/templates/rhsso-crw-client.yml.j2
+++ b/roles/tssc-platform/configuration/crw/templates/rhsso-crw-client.yml.j2
@@ -19,4 +19,4 @@
         - 'http://codeready-{{ crw_project_name }}.apps.{{ full_cluster_name }}/*'
       rootUrl: 'http://codeready-{{ crw_project_name }}.apps.{{ full_cluster_name }}/'
       protocol: openid-connect
-
+      standardFlowEnabled: true

--- a/roles/tssc-platform/configuration/gitea/templates/rhsso-gitea-client.yml.j2
+++ b/roles/tssc-platform/configuration/gitea/templates/rhsso-gitea-client.yml.j2
@@ -21,3 +21,4 @@
         - 'https://gitea-{{ gitea_project_name }}.apps.{{ subdomain }}/*'
       rootUrl: 'https://gitea-{{ gitea_project_name }}.apps.{{ subdomain }}/'
       protocol: openid-connect
+      standardFlowEnabled: true

--- a/roles/tssc-platform/configuration/quay/templates/rhsso-quay-client.yml.j2
+++ b/roles/tssc-platform/configuration/quay/templates/rhsso-quay-client.yml.j2
@@ -21,4 +21,4 @@
         - 'https://{{ quay_route }}/oauth2/rhsso/callback'
       rootUrl: 'https://{{ quay_route }}/'
       protocol: openid-connect
-
+      standardFlowEnabled: true

--- a/roles/tssc-platform/configuration/rhsso/templates/rhsso-ocp-client.yml.j2
+++ b/roles/tssc-platform/configuration/rhsso/templates/rhsso-ocp-client.yml.j2
@@ -23,6 +23,7 @@
         - 'https://oauth-openshift.apps.{{ subdomain }}/*'
       rootUrl: 'https://console-openshift-console.apps.{{ subdomain }}/'
       protocol: openid-connect
+      standardFlowEnabled: true
 
 ## FIXME Need to copy keycloak-client-secret-openshift from rhsso namespace
 # Add Client ID and Secret to OpenShift Config

--- a/roles/tssc-platform/configuration/sonarqube/templates/rhsso-sonar4-client.yml.j2
+++ b/roles/tssc-platform/configuration/sonarqube/templates/rhsso-sonar4-client.yml.j2
@@ -29,6 +29,7 @@
         saml.client.signature: 'false'
         saml.signature.algorithm: RSA_SHA256
         saml_name_id_format: username
+      standardFlowEnabled: true
 
       protocolMappers:
       - config:


### PR DESCRIPTION
Oddly, this also needs to include the SAML clients as without this set Keycloak will fail SAML authentication. The standardFlowEnabled parameter for the Client will be set to 'true' automatically by Keycloak if you create the client via the UI, but not when creating them using the `KeycloakClient` CR.

This is necessary to allow users to login to these applications via browser-based workflows. Mattermost already has this enabled on it's KeycloakClient CR, so is not included here.

There is additional work to do with the client secrets when using confidential OIDC clients, namely making sure that if they are modified in Keycloak that the corresponding application config is updated and causes a redeploy of the app.