### PR TITLE
Wait for the 'status' field to exist before querying conditions.

### DIFF
--- a/roles/tssc-pipeline/tasks/main.yml
+++ b/roles/tssc-pipeline/tasks/main.yml
@@ -5,7 +5,9 @@
     kind: TsscPlatform
     namespace: '{{ tssc_namespace }}'
   register: tssc_platform_result
-  until: tssc_platform_result.resources[0].status | json_query("conditions[?(@.reason=='Successful')]")
+  until:
+    - tssc_platform_result.resources[0].status is defined
+    - tssc_platform_result.resources[0].status | json_query("conditions[?(@.reason=='Successful')]")
   retries: 20
   delay: 60
 

--- a/roles/tssc-platform/configuration/gitea/tasks/main.yml
+++ b/roles/tssc-platform/configuration/gitea/tasks/main.yml
@@ -5,7 +5,9 @@
     namespace: '{{ gitea_project_name }}'
     name: gitea
   register: result
-  until: result.resources[0].status | json_query("conditions[?(@.reason=='Successful')]")
+  until:
+    - result.resources[0].status is defined
+    - result.resources[0].status | json_query("conditions[?(@.reason=='Successful')]")
   retries: 10
   delay: 30
 


### PR DESCRIPTION
Without this, if we get to the check before the corresponding Operator has taken
over the resource then the status field will not exist, and we will fail the playbook
unnecessarily.