### PR TITLE
Improve handling of KeycloakClient CRs and client secrets.

### DIFF
--- a/hack/operate.conf
+++ b/hack/operate.conf
@@ -1,5 +1,5 @@
 IMG=quay.io/redhatgov/tssc-operator
 KIND=TsscPlatform
 CR_SAMPLE=redhatgov_v1alpha1_tsscplatform_openshift.yaml
-VERSION=0.2.5
+VERSION=0.2.6
 CHANNELS=alpha

--- a/playbooks/tssc.yml
+++ b/playbooks/tssc.yml
@@ -53,6 +53,11 @@
         msg: Unable to continue without rhedsord variables set
       when: rhedsord_included is not defined or not rhedsord_included
 
+    - name: Ensure temporary directory exists
+      file:
+        path: "{{ tmp_dir }}"
+        state: directory
+
     - include_tasks: cleanup-tssc-platform.yml
       when: cr_state == 'absent'
 

--- a/roles/tssc-platform/configuration/gitea/tasks/gitea_rhsso.yml
+++ b/roles/tssc-platform/configuration/gitea/tasks/gitea_rhsso.yml
@@ -1,32 +1,53 @@
 ---
-
-- name: Generate a Gitea secret for RHSSO
-  set_fact:
-    rhsso_gitea_secret: "{{ lookup('password', tmp_dir + '/rhsso_gitea.secret length=15 chars=ascii_letters') }}"
-
 - name: Create RHSSO Client definition for Gitea
   k8s:
     definition: '{{ lookup("template", "../templates/rhsso-gitea-client.yml.j2")|from_yaml }}'
   register: rhsso_client
 
-- name: Check if Gitea OAuth provider exists
-  shell: |
-    oc='{{ oc_cli }}'
+- name: Wait for Gitea KeycloakClient to reconcile
+  k8s_info:
+    api_version: keycloak.org/v1alpha1
+    kind: KeycloakClient
+    name: gitea-client
+    namespace: "{{ rhsso_project_name }}"
+  register: gitea_kc
+  until:
+    - gitea_kc.resources|length > 0
+    - gitea_kc.resources[0].status is defined
+    - gitea_kc.resources[0].status['ready']
+  delay: 10
+  retries: 6
 
-    pod=$($oc get pods -n {{ gitea_project_name }} -l {{ gitea_pod_label }} -o jsonpath='{.items[0].metadata.name}')
-    $oc exec $pod -n {{ gitea_project_name }} -- /home/gitea/gitea --config=/home/gitea/conf/app.ini admin auth list |& grep -F rhsso
-  changed_when: false
-  failed_when: false
-  register: gitea_oauth_config
+- name: Wait for client secret to be created
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: keycloak-client-secret-gitea
+    namespace: "{{ rhsso_project_name }}"
+  register: gitea_secret
+  until:
+    - "gitea_secret.resources[0].data['CLIENT_SECRET'] != ''"
+  retries: 12
+  delay: 5
 
+- name: Fetch Gitea secret for RHSSO
+  set_fact:
+    rhsso_gitea_secret: "{{ gitea_secret.resources[0].data['CLIENT_SECRET'] | b64decode }}"
+
+# TODO: this should all be part of the Gitea operator
+# unfortunately, when we move to Secret-based client secrets we cannot
+# easily know when the Secret has changed, so updating an existing client secret
+# is difficult. Plus, Gitea CLI doesn't provide a means to check that no
+# changes were made to OAuth config - all update commands will cause an UPDATE
+# query regardless.
 - name: Configure RHSSO as an OAuth2 provider for Gitea
   shell: |
     oc='{{ oc_cli }}'
     pod=$($oc get pods -n {{ gitea_project_name }} -l {{ gitea_pod_label }} -o jsonpath='{.items[0].metadata.name}')
-
-    {% if "rhsso" not in gitea_oauth_config.stdout %}
-      echo "Gitea needs to be configured with the RHSSO client"
-      output=$($oc exec $pod -n {{ gitea_project_name }} -- /home/gitea/gitea --config=/home/gitea/conf/app.ini admin auth add-oauth --name=rhsso --provider openidConnect --key {{ rhsso_gitea_client_id }} --secret {{ rhsso_gitea_client_id }} --auto-discover-url  https://keycloak-{{ rhsso_project_name }}.apps.{{ subdomain }}/auth/realms/{{ rhsso_realm_name }}/.well-known/openid-configuration 2>&1)
+    gitea="$oc exec $pod -n {{ gitea_project_name }} -- /home/gitea/gitea --config=/home/gitea/conf/app.ini"
+    $gitea admin auth list |& grep -F rhsso
+    if [ $? -gt 0 ]; then
+      output=$($gitea admin auth add-oauth --name=rhsso --provider openidConnect --key {{ rhsso_gitea_client_id }} --secret {{ rhsso_gitea_secret }} --auto-discover-url  https://keycloak-{{ rhsso_project_name }}.apps.{{ subdomain }}/auth/realms/{{ rhsso_realm_name }}/.well-known/openid-configuration 2>&1)
       if echo "$output" | grep -qF 'login source already exists'; then
           echo ok
       elif echo "$output" | grep -qF 'Failed to run app'; then
@@ -36,21 +57,9 @@
       else
           echo failed
       fi
-    {% elif rhsso_client.changed %}
-      echo "Gitea RHSSO client needs new secret updated"
-      output=$($oc exec $pod -n {{ gitea_project_name }} -- /home/gitea/gitea --config=/home/gitea/conf/app.ini admin auth update-oauth --id {{ gitea_oauth_config.stdout[0] }} --secret {{ rhsso_gitea_secret }} 2>&1)
-      if echo "$output" | grep -qF 'UPDATE'; then
-          echo changed
-      elif echo "$output" | grep -qF 'Failed to run app'; then
-          echo failed
-      else
-          echo ok
-      fi
-    {% else %}
-      echo "Gitea RHSSO client doesn't need updated"
+    else
       echo ok
-    {% endif %}
-    echo "$output" >&2
+    fi
   register: gitea_rhsso_oauth
   changed_when: '"changed" in gitea_rhsso_oauth.stdout_lines'
   failed_when: '"failed" in gitea_rhsso_oauth.stdout_lines'
@@ -64,6 +73,7 @@
       namespace: '{{ gitea_project_name }}'
       name: "{{ (gitea_pod.resources|first).metadata.name }}"
       state: absent
+      wait: true
 
   - name: Wait **again** for Gitea to finish being created with RHSSO settings
     k8s_info:

--- a/roles/tssc-platform/configuration/gitea/tasks/main.yml
+++ b/roles/tssc-platform/configuration/gitea/tasks/main.yml
@@ -8,8 +8,8 @@
   until:
     - result.resources[0].status is defined
     - result.resources[0].status | json_query("conditions[?(@.reason=='Successful')]")
-  retries: 10
-  delay: 30
+  retries: 30
+  delay: 10
 
 - name: Get Gitea Admin Secret
   k8s_info:

--- a/roles/tssc-platform/configuration/gitea/templates/rhsso-gitea-client.yml.j2
+++ b/roles/tssc-platform/configuration/gitea/templates/rhsso-gitea-client.yml.j2
@@ -12,7 +12,6 @@
         app: {{ rhsso_app_label }}
     client:
       clientId: {{ rhsso_gitea_client_id }}
-      secret: {{ rhsso_gitea_secret }}
       name: {{ rhsso_gitea_client_id }}
       enabled: true
       clientAuthenticatorType: client-secret

--- a/roles/tssc-platform/configuration/quay/tasks/quay_rhsso.yml
+++ b/roles/tssc-platform/configuration/quay/tasks/quay_rhsso.yml
@@ -1,9 +1,39 @@
 ---
+- name: Create RHSSO Client definition for Quay
+  k8s:
+    definition: '{{ lookup("template", "../templates/rhsso-quay-client.yml.j2")|from_yaml }}'
+
+- name: Wait for Quay KeycloakClient to reconcile
+  k8s_info:
+    api_version: keycloak.org/v1alpha1
+    kind: KeycloakClient
+    name: quay-client
+    namespace: "{{ rhsso_project_name }}"
+  register: quay_kc
+  until:
+    - quay_kc.resources|length > 0
+    - quay_kc.resources[0].status is defined
+    - quay_kc.resources[0].status.ready
+  delay: 10
+  retries: 6
+
+- name: Wait for client secret to be created
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "keycloak-client-secret-{{ rhsso_quay_client_id }}"
+    namespace: "{{ rhsso_project_name }}"
+  register: quay_secret
+  until:
+    - "quay_secret.resources[0].data['CLIENT_SECRET'] != ''"
+  retries: 12
+  delay: 5
 
 - name: Generate a Quay secret for RHSSO
   set_fact:
-    rhsso_quay_secret: "{{ lookup('password', tmp_dir +'/rhsso_quay.secret length=15 chars=ascii_letters') }}"
+    rhsso_quay_secret: "{{ quay_secret.resources[0].data['CLIENT_SECRET'] | b64decode }}"
 
+# TODO: the below (updating Quay config for SSO) should be moved to the Quay Operator.
 - name: Get Quay pod info
   k8s_info:
     api_version: v1
@@ -13,9 +43,6 @@
       - "quay-enterprise-component=app"
   register: quay_pod
 
-- name: Create RHSSO Client definition for Quay
-  k8s:
-    definition: '{{ lookup("template", "../templates/rhsso-quay-client.yml.j2")|from_yaml }}'
 
 - name: Get Quay config secret
   k8s_info:

--- a/roles/tssc-platform/configuration/quay/templates/rhsso-quay-client.yml.j2
+++ b/roles/tssc-platform/configuration/quay/templates/rhsso-quay-client.yml.j2
@@ -12,7 +12,6 @@
         app: {{ rhsso_app_label }}
     client:
       clientId: {{ rhsso_quay_client_id }}
-      secret: {{ rhsso_quay_secret }}
       name: {{ rhsso_quay_client_id }}
       enabled: true
       clientAuthenticatorType: client-secret

--- a/roles/tssc-platform/configuration/sonarqube/tasks/sonarqube_rhsso.yml
+++ b/roles/tssc-platform/configuration/sonarqube/tasks/sonarqube_rhsso.yml
@@ -5,6 +5,18 @@
     k8s:
       definition: '{{ lookup("template", "../templates/rhsso-sonar4-client.yml.j2")|from_yaml }}'
 
+  - name: Wait for SonarQube KeycloakClient to reconcile
+    k8s_info:
+      api_version: keycloak.org/v1alpha1
+      kind: KeycloakClient
+      name: sonarqube-client
+      namespace: "{{ rhsso_project_name }}"
+    register: sonarqube_kc
+    until:
+      - sonarqube_kc.resources|length > 0
+      - sonarqube_kc.resources[0].status is defined
+      - sonarqube_kc.resources[0].status.ready
+
   - name: Get RHSSO login
     k8s_info:
       api_version: v1


### PR DESCRIPTION
This ensures that the KeycloakClient secret is not regenerated on each reconcilation loop. We also no longer generate a password and instead allow the Keycloak operator to do so - when the Client is created on the server a UUID is generated for the client secret, which the Operator then fetches and stores in the Secret.

Unfortunately, this change means that Gitea config no longer has a simple means to identify when the client-secret has changed and issue the update-oauth commands, and so with this change that capability is removed. This should probably end up being a function of the Gitea operator (e.g. watching for last updated times of the corresponding Secret compared with the last reconciliation time of the CR).