### PR TITLE
Fix some minor syntax issues in realm.yaml.j2

### DIFF
--- a/roles/ploigos-platform/sso-integration/templates/realm.yml.j2
+++ b/roles/ploigos-platform/sso-integration/templates/realm.yml.j2
@@ -3,8 +3,8 @@ kind: KeycloakRealm
 metadata:
   name: openshift
   namespace: {{ ploigos_namespace }}
-labels:
-  app: rhsso
+  labels:
+    app: {{ rhsso_app_label }}
 spec:
   realm:
     id: openshift
@@ -13,4 +13,4 @@ spec:
     displayName: Ploigos OpenShift Realm
   instanceSelector:
     matchLabels:
-    app: rhsso
+      app: {{ rhsso_app_label }}


### PR DESCRIPTION
Labels repositioned under the metadata key. Fix indentation on instanceSelector.matchLabels. Also use {{ rhsso_app_label }} in place of hardcoded 'rhsso'.