### PR TITLE
Documentation fix in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -43,7 +43,7 @@ export OCP_USERNAME=replace
 export OCP_PASSWORD='replace'
 export QUAY_USERNAME=replace
 export QUAY_PASSWORD='replace'
-export OPERATOR_IMAGE=quay.io/replace/ploigos-operator:test
+export OPERATOR_IMAGE=quay.io/replace/ploigos-operator
 ```
 
 Make sure the repo provided is public for the env var OPERATOR_IMAGE


### PR DESCRIPTION
OPERATOR_IMAGE should not end in :test, otherwise ./hack/operate.sh --image=$OPERATOR_IMAGE --version=latest post-fixes a tag and you end up trying to docker push to something like quay.io/me/my-image:test:latest